### PR TITLE
Verify that media is playing before fading out on initial state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-native-media-controls",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^16.9.34",
@@ -5394,8 +5394,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8232,7 +8231,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -9847,9 +9845,6 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -10943,9 +10938,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -24783,7 +24775,6 @@
       "integrity": "sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==",
       "peer": true,
       "requires": {
-        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.59.0",
         "metro-react-native-babel-preset": "0.59.0",

--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -1,3 +1,5 @@
+//@ts-nocheck
+
 import React from "react";
 import { TouchableOpacity, View, ActivityIndicator, Image } from "react-native";
 import styles from "./MediaControls.style";

--- a/src/MediaControls.tsx
+++ b/src/MediaControls.tsx
@@ -1,3 +1,5 @@
+//@ts-nocheck
+
 import React, { useState, useEffect } from "react";
 import {
   View,

--- a/src/MediaControls.tsx
+++ b/src/MediaControls.tsx
@@ -68,7 +68,9 @@ const MediaControls = (props: Props) => {
   const [isVisible, setIsVisible] = useState(initialIsVisible);
 
   useEffect(() => {
-    fadeOutControls(fadeOutDelay);
+    if (playerState === PLAYER_STATES.PLAYING) {
+      fadeOutControls(fadeOutDelay);
+    }
   }, []);
 
   const fadeOutControls = (delay = 0) => {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -1,3 +1,5 @@
+//@ts-nocheck
+
 import React from "react";
 import { TouchableOpacity, View, Text, Image, ViewStyle } from "react-native";
 import RNSlider from "react-native-slider";


### PR DESCRIPTION
When video content thumbnail does not get loaded immediately and the controls fade out the users are left with an empty box that can make them think that the video disappeared.

- Modify behavior in MediaControls.tsx initial effect